### PR TITLE
Add footer with selection summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 <body>
   <h1>Select One Team per Group</h1>
   <div id="groups-container"></div>
+  <footer id="selection-footer">
+    <div id="selected-teams"></div>
+    <span id="selected-count"></span>
+    <button id="submit-button" disabled>Submit</button>
+  </footer>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,23 @@ function getFlagImg(countryName) {
   return `<img src="https://flagcdn.com/w40/${code.toLowerCase()}.png" alt="${countryName} flag" style="width: 20px; vertical-align: middle; margin-right: 4px;">`;
 }
 
+const selectedTeams = {};
+
+function updateFooter(totalGroups) {
+  const footerContainer = document.getElementById("selected-teams");
+  footerContainer.innerHTML = "";
+  Object.values(selectedTeams).forEach(team => {
+    const img = document.createElement("img");
+    img.src = team.logosrc;
+    img.alt = team.TeamName;
+    img.onerror = function() { this.onerror = null; this.src = 'img/logos/default.png'; };
+    footerContainer.appendChild(img);
+  });
+  document.getElementById("selected-count").textContent = `${Object.keys(selectedTeams).length}/${totalGroups} selected`;
+  const submitButton = document.getElementById("submit-button");
+  submitButton.disabled = Object.keys(selectedTeams).length !== totalGroups;
+}
+
 fetch('teams.json')
   .then(response => response.json())
   .then(teams => {
@@ -38,6 +55,9 @@ fetch('teams.json')
       if (!groups[team.group]) groups[team.group] = [];
       groups[team.group].push(team);
     });
+
+    const totalGroups = Object.keys(groups).length;
+    updateFooter(totalGroups);
 
     for (const group in groups) {
       const section = document.createElement("div");
@@ -70,12 +90,17 @@ fetch('teams.json')
           if (!isAlreadySelected) {
             // Select new card and gray out others
             card.classList.add("selected");
+            selectedTeams[group] = team;
             cards.forEach(c => {
               if (!c.classList.contains("selected")) {
                 c.classList.add("disabled");
               }
             });
+          } else {
+            delete selectedTeams[group];
           }
+
+          updateFooter(totalGroups);
         });
 
         grid.appendChild(card);

--- a/style.css
+++ b/style.css
@@ -62,3 +62,28 @@ h1 {
   border-color: #007bff;
   background-color: #f0f8ff;
 }
+
+footer#selection-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-top: 1px solid #ccc;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+#selected-teams img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  margin-right: 4px;
+}
+
+#submit-button:disabled {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- add footer area to show selected team logos
- style sticky footer and disable/enable submit button
- track selections in script and update footer with count

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683f0849de8883268654e883745447ce