### PR TITLE
Improve rules page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,19 +11,18 @@
     <a href="select.html">Team Selection</a>
   </nav>
   <main>
-    <h1>Welcome to the Club World Cup Draft</h1>
-    <p>This draft lets you compete against friends by picking clubs from the Club World Cup groups. Here is how it works:</p>
+    <div class="title-bar">
+      <img src="img/clubworldcuplogo.png" alt="Club World Cup logo" class="logo">
+      <h1>Club World Cup Draft 2025</h1>
+      <img src="img/avinor.PNG" alt="Avinor logo" class="logo">
+    </div>
+    <p>Compete with friends by picking clubs from the groups. Here's the idea:</p>
     <ul>
-      <li><strong>Pick one team from every group.</strong></li>
-      <li>When your team plays a match, you earn <strong>3 points</strong> for a win or <strong>1 point</strong> for a draw.</li>
-      <li>You get bonus points when other players picked the team your club is playing against:
-        <ul>
-          <li><strong>Win:</strong> +3 points for each opposing player who chose the other team.</li>
-          <li><strong>Draw:</strong> +1 point for each opposing player who chose the other team.</li>
-        </ul>
-      </li>
+      <li><strong>Pick one team from each group.</strong></li>
+      <li>A win gives you <strong>3 points</strong>; a draw gives <strong>1 point</strong>.</li>
+      <li>If an opponent picked the other team, you score the same points again for each of them.</li>
     </ul>
-    <p>The total from all of your club's matches decides your final score. The player with the most points after the tournament wins!</p>
+    <p>Your total from every match decides the winner.</p>
 
     <div class="example">
       <h2>Scoring Example</h2>
@@ -32,10 +31,10 @@
         <span class="score">2 - 1</span>
         <img src="img/logos/alhilal.png" alt="Al-Hilal logo">
       </div>
-      <p>Two other players picked Al-Hilal. Real Madrid wins:</p>
+      <p>Two others picked Al-Hilal <img src="img/person.svg" class="player-icon" alt="player"><img src="img/person.svg" class="player-icon" alt="player">. Real Madrid wins:</p>
       <ul>
         <li>Win points: 3</li>
-        <li>Bonus: 3 points &times; 2 players = 6</li>
+        <li>Bonus: 3 points &times; 2 <img src="img/person.svg" class="player-icon" alt="player"> = 6</li>
         <li><strong>Total for this match: 9 points</strong></li>
       </ul>
     </div>
@@ -46,15 +45,15 @@
         <span class="score">1 - 1</span>
         <img src="img/logos/alhilal.png" alt="Al-Hilal logo">
       </div>
-      <p>If the same match ended in a draw:</p>
+      <p>If it ends in a draw with the same two opponents <img src="img/person.svg" class="player-icon" alt="player"><img src="img/person.svg" class="player-icon" alt="player">:</p>
       <ul>
         <li>Draw points: 1</li>
-        <li>Bonus: 1 point &times; 2 players = 2</li>
+        <li>Bonus: 1 point &times; 2 <img src="img/person.svg" class="player-icon" alt="player"> = 2</li>
         <li><strong>Total for this match: 3 points</strong></li>
       </ul>
     </div>
 
-    <a href="select.html" class="start-btn">Get Startet</a>
+    <a href="select.html" class="start-btn">Get Started</a>
   </main>
 </body>
 </html>

--- a/rules.css
+++ b/rules.css
@@ -29,6 +29,30 @@ main {
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
+.title-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.title-bar h1 {
+  flex: 1;
+  text-align: center;
+  margin: 0;
+  font-size: 2em;
+}
+
+.title-bar img.logo {
+  height: 60px;
+}
+
+.player-icon {
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+}
+
 .example {
   border: 1px solid #ccc;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- add title bar with tournament and sponsor logos
- simplify rules and examples
- use player icons in examples
- minor typo fix

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f143d1bd483269d30340d89c44da2